### PR TITLE
Add Common.Logging.NLog53 adapter

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ dotnet_csproj:
   informational_version: '{version}'
 before_build:
   - nuget restore
+test_script:
+  - dotnet test .\Common.Logging.Scopes.Tests\Common.Logging.Scopes.Tests.csproj -c %configuration% --no-build
+  - dotnet test .\Common.Logging.NLog53.Tests\Common.Logging.NLog53.Tests.csproj -c %configuration% --no-build
 build:
   publish_nuget: true
   publish_nuget_symbols: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,8 @@
 version: '{build}'
 skip_tags: true
+branches:
+  only:
+    - /.*/
 image: Visual Studio 2022
 configuration: Release
 dotnet_csproj:

--- a/Common.Logging.Extras.sln
+++ b/Common.Logging.Extras.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31019.35
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11519.219 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Logging.Scopes", "Common.Logging.Scopes\Common.Logging.Scopes.csproj", "{1285E40C-6706-4881-A809-5DD2199106EB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Logging.NLog45", "Common.Logging.NLog45\Common.Logging.NLog45.csproj", "{6595A29B-6666-450F-B2D6-849B685C1E19}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Logging.Scopes.Tests", "Common.Logging.Scopes.Tests\Common.Logging.Scopes.Tests.csproj", "{8AC2B504-7B6D-4EEB-B96E-17D9ED2E85BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Logging.NLog53", "Common.Logging.NLog53\Common.Logging.NLog53.csproj", "{E26AEB93-97C6-41EB-8108-B46247C348CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Logging.NLog53.Tests", "Common.Logging.NLog53.Tests\Common.Logging.NLog53.Tests.csproj", "{CC8D22E0-A6AB-4927-9810-4EEEFC22C6A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,14 @@ Global
 		{8AC2B504-7B6D-4EEB-B96E-17D9ED2E85BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AC2B504-7B6D-4EEB-B96E-17D9ED2E85BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AC2B504-7B6D-4EEB-B96E-17D9ED2E85BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E26AEB93-97C6-41EB-8108-B46247C348CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E26AEB93-97C6-41EB-8108-B46247C348CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E26AEB93-97C6-41EB-8108-B46247C348CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E26AEB93-97C6-41EB-8108-B46247C348CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC8D22E0-A6AB-4927-9810-4EEEFC22C6A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC8D22E0-A6AB-4927-9810-4EEEFC22C6A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC8D22E0-A6AB-4927-9810-4EEEFC22C6A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC8D22E0-A6AB-4927-9810-4EEEFC22C6A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Common.Logging.NLog53/Common.Logging.NLog53.csproj
+++ b/Common.Logging.NLog53/Common.Logging.NLog53.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>disable</Nullable>
+		<Company>Uanataca S.A.U.</Company>
+		<RootNamespace>Common.Logging.NLog53</RootNamespace>
+		<PackageId>Common.Logging.NLog53</PackageId>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Authors>Evicertia</Authors>
+		<Copyright>Copyright Uanataca S.A.U. 2026</Copyright>
+		<PackageProjectUrl>https://github.com/evicertia/Common.Logging.Extras</PackageProjectUrl>
+		<Description>NLog 5.3.x adapter for Common.Logging.</Description>
+		<PackageTags>Common.Logging;NLog;Logging;Adapter</PackageTags>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/evicertia/Common.Logging.Extras</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<AssemblyVersion>0.0.0.0</AssemblyVersion>
+		<FileVersion>0.0.0.0</FileVersion>
+		<Version>0.0.0.0</Version>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Common.Logging" Version="3.4.1" />
+		<PackageReference Include="NLog" Version="5.3.4" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" Link="README.md" />
+	</ItemGroup>
+
+</Project>

--- a/Common.Logging.NLog53/NLogGlobalVariablesContext.cs
+++ b/Common.Logging.NLog53/NLogGlobalVariablesContext.cs
@@ -1,0 +1,33 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using Context = NLog.GlobalDiagnosticsContext;
+
+namespace Common.Logging.NLog53
+{
+	public sealed class NLogGlobalVariablesContext : IVariablesContext
+	{
+		public void Set(string key, object value) => Context.Set(key, value);
+		public object Get(string key) => Context.GetObject(key);
+		public bool Contains(string key) => Context.Contains(key);
+		public void Remove(string key) => Context.Remove(key);
+		public void Clear() => Context.Clear();
+	}
+}

--- a/Common.Logging.NLog53/NLogLogger.cs
+++ b/Common.Logging.NLog53/NLogLogger.cs
@@ -1,0 +1,171 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using LogEventInfo = NLog.LogEventInfo;
+using LoggerNLog = NLog.Logger;
+using LogLevelNLog = NLog.LogLevel;
+
+namespace Common.Logging.NLog53
+{
+	public class NLogLogger : ILog
+	{
+		private readonly LoggerNLog _logger;
+
+		public NLogLogger(LoggerNLog logger)
+		{
+			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		public static bool FavorLogicalVariableContexts { get; set; }
+
+		public bool IsTraceEnabled => _logger.IsTraceEnabled;
+		public bool IsDebugEnabled => _logger.IsDebugEnabled;
+		public bool IsInfoEnabled => _logger.IsInfoEnabled;
+		public bool IsWarnEnabled => _logger.IsWarnEnabled;
+		public bool IsErrorEnabled => _logger.IsErrorEnabled;
+		public bool IsFatalEnabled => _logger.IsFatalEnabled;
+
+		public IVariablesContext GlobalVariablesContext => new NLogGlobalVariablesContext();
+		public IVariablesContext ThreadVariablesContext => FavorLogicalVariableContexts ? LogicalThreadVariablesContext : PerThreadVariablesContext;
+		public INestedVariablesContext NestedThreadVariablesContext => FavorLogicalVariableContexts ? NestedLogicalThreadVariablesContext : NestedPerThreadVariablesContext;
+
+		public IVariablesContext PerThreadVariablesContext => new NLogThreadVariablesContext();
+		public INestedVariablesContext NestedPerThreadVariablesContext => new NLogNestedThreadVariablesContext();
+		public IVariablesContext LogicalThreadVariablesContext => new NLogLogicalThreadVariablesContext();
+		public INestedVariablesContext NestedLogicalThreadVariablesContext => new NLogNestedLogicalThreadVariablesContext();
+
+		public void Trace(object message) => WriteObject(LogLevelNLog.Trace, message, null, IsTraceEnabled);
+		public void Trace(object message, Exception exception) => WriteObject(LogLevelNLog.Trace, message, exception, IsTraceEnabled);
+		public void Trace(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Trace, null, formatMessageCallback, null, IsTraceEnabled);
+		public void Trace(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Trace, exception, formatMessageCallback, null, IsTraceEnabled);
+		public void Trace(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Trace, null, formatMessageCallback, formatProvider, IsTraceEnabled);
+		public void Trace(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Trace, exception, formatMessageCallback, formatProvider, IsTraceEnabled);
+		public void TraceFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Trace, null, null, format, args, IsTraceEnabled);
+		public void TraceFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Trace, null, exception, format, args, IsTraceEnabled);
+		public void TraceFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Trace, formatProvider, null, format, args, IsTraceEnabled);
+		public void TraceFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Trace, formatProvider, exception, format, args, IsTraceEnabled);
+
+		public void Debug(object message) => WriteObject(LogLevelNLog.Debug, message, null, IsDebugEnabled);
+		public void Debug(object message, Exception exception) => WriteObject(LogLevelNLog.Debug, message, exception, IsDebugEnabled);
+		public void Debug(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Debug, null, formatMessageCallback, null, IsDebugEnabled);
+		public void Debug(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Debug, exception, formatMessageCallback, null, IsDebugEnabled);
+		public void Debug(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Debug, null, formatMessageCallback, formatProvider, IsDebugEnabled);
+		public void Debug(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Debug, exception, formatMessageCallback, formatProvider, IsDebugEnabled);
+		public void DebugFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Debug, null, null, format, args, IsDebugEnabled);
+		public void DebugFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Debug, null, exception, format, args, IsDebugEnabled);
+		public void DebugFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Debug, formatProvider, null, format, args, IsDebugEnabled);
+		public void DebugFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Debug, formatProvider, exception, format, args, IsDebugEnabled);
+
+		public void Info(object message) => WriteObject(LogLevelNLog.Info, message, null, IsInfoEnabled);
+		public void Info(object message, Exception exception) => WriteObject(LogLevelNLog.Info, message, exception, IsInfoEnabled);
+		public void Info(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Info, null, formatMessageCallback, null, IsInfoEnabled);
+		public void Info(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Info, exception, formatMessageCallback, null, IsInfoEnabled);
+		public void Info(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Info, null, formatMessageCallback, formatProvider, IsInfoEnabled);
+		public void Info(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Info, exception, formatMessageCallback, formatProvider, IsInfoEnabled);
+		public void InfoFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Info, null, null, format, args, IsInfoEnabled);
+		public void InfoFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Info, null, exception, format, args, IsInfoEnabled);
+		public void InfoFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Info, formatProvider, null, format, args, IsInfoEnabled);
+		public void InfoFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Info, formatProvider, exception, format, args, IsInfoEnabled);
+
+		public void Warn(object message) => WriteObject(LogLevelNLog.Warn, message, null, IsWarnEnabled);
+		public void Warn(object message, Exception exception) => WriteObject(LogLevelNLog.Warn, message, exception, IsWarnEnabled);
+		public void Warn(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Warn, null, formatMessageCallback, null, IsWarnEnabled);
+		public void Warn(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Warn, exception, formatMessageCallback, null, IsWarnEnabled);
+		public void Warn(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Warn, null, formatMessageCallback, formatProvider, IsWarnEnabled);
+		public void Warn(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Warn, exception, formatMessageCallback, formatProvider, IsWarnEnabled);
+		public void WarnFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Warn, null, null, format, args, IsWarnEnabled);
+		public void WarnFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Warn, null, exception, format, args, IsWarnEnabled);
+		public void WarnFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Warn, formatProvider, null, format, args, IsWarnEnabled);
+		public void WarnFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Warn, formatProvider, exception, format, args, IsWarnEnabled);
+
+		public void Error(object message) => WriteObject(LogLevelNLog.Error, message, null, IsErrorEnabled);
+		public void Error(object message, Exception exception) => WriteObject(LogLevelNLog.Error, message, exception, IsErrorEnabled);
+		public void Error(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Error, null, formatMessageCallback, null, IsErrorEnabled);
+		public void Error(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Error, exception, formatMessageCallback, null, IsErrorEnabled);
+		public void Error(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Error, null, formatMessageCallback, formatProvider, IsErrorEnabled);
+		public void Error(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Error, exception, formatMessageCallback, formatProvider, IsErrorEnabled);
+		public void ErrorFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Error, null, null, format, args, IsErrorEnabled);
+		public void ErrorFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Error, null, exception, format, args, IsErrorEnabled);
+		public void ErrorFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Error, formatProvider, null, format, args, IsErrorEnabled);
+		public void ErrorFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Error, formatProvider, exception, format, args, IsErrorEnabled);
+
+		public void Fatal(object message) => WriteObject(LogLevelNLog.Fatal, message, null, IsFatalEnabled);
+		public void Fatal(object message, Exception exception) => WriteObject(LogLevelNLog.Fatal, message, exception, IsFatalEnabled);
+		public void Fatal(Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Fatal, null, formatMessageCallback, null, IsFatalEnabled);
+		public void Fatal(Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Fatal, exception, formatMessageCallback, null, IsFatalEnabled);
+		public void Fatal(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback) => WriteCallback(LogLevelNLog.Fatal, null, formatMessageCallback, formatProvider, IsFatalEnabled);
+		public void Fatal(IFormatProvider formatProvider, Action<FormatMessageHandler> formatMessageCallback, Exception exception) => WriteCallback(LogLevelNLog.Fatal, exception, formatMessageCallback, formatProvider, IsFatalEnabled);
+		public void FatalFormat(string format, params object[] args) => WriteFormat(LogLevelNLog.Fatal, null, null, format, args, IsFatalEnabled);
+		public void FatalFormat(string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Fatal, null, exception, format, args, IsFatalEnabled);
+		public void FatalFormat(IFormatProvider formatProvider, string format, params object[] args) => WriteFormat(LogLevelNLog.Fatal, formatProvider, null, format, args, IsFatalEnabled);
+		public void FatalFormat(IFormatProvider formatProvider, string format, Exception exception, params object[] args) => WriteFormat(LogLevelNLog.Fatal, formatProvider, exception, format, args, IsFatalEnabled);
+
+		private void WriteObject(LogLevelNLog level, object message, Exception exception, bool enabled)
+		{
+			if (!enabled)
+				return;
+
+			if (message is string text)
+			{
+				Write(level, null, exception, text, null);
+				return;
+			}
+
+			exception ??= message as Exception;
+			Write(level, null, exception, "{0}", new[] { message });
+		}
+
+		private void WriteCallback(LogLevelNLog level, Exception exception, Action<FormatMessageHandler> callback, IFormatProvider formatProvider, bool enabled)
+		{
+			if (!enabled || callback == null)
+				return;
+
+			var format = string.Empty;
+			object[] args = null;
+
+			callback((msgFormat, msgArgs) =>
+			{
+				format = msgFormat;
+				args = msgArgs;
+				return formatProvider != null
+					? string.Format(formatProvider, msgFormat, msgArgs)
+					: string.Format(msgFormat, msgArgs);
+			});
+
+			Write(level, formatProvider, exception, format, args);
+		}
+
+		private void WriteFormat(LogLevelNLog level, IFormatProvider formatProvider, Exception exception, string format, object[] args, bool enabled)
+		{
+			if (!enabled)
+				return;
+
+			Write(level, formatProvider, exception, format, args);
+		}
+
+		private void Write(LogLevelNLog level, IFormatProvider formatProvider, Exception exception, string format, object[] args)
+		{
+			var logEvent = new LogEventInfo(level, _logger.Name, formatProvider, format, args, exception);
+			_logger.Log(logEvent);
+		}
+	}
+}

--- a/Common.Logging.NLog53/NLogLoggerFactoryAdapter.cs
+++ b/Common.Logging.NLog53/NLogLoggerFactoryAdapter.cs
@@ -1,0 +1,77 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using Common.Logging.Configuration;
+using Common.Logging.Factory;
+
+namespace Common.Logging.NLog53
+{
+	public class NLogLoggerFactoryAdapter : AbstractCachingLoggerFactoryAdapter
+	{
+		public NLogLoggerFactoryAdapter()
+			: this(null)
+		{ }
+
+		public NLogLoggerFactoryAdapter(NameValueCollection properties)
+			: base(true)
+		{
+			var configType = string.Empty;
+			var configFile = string.Empty;
+
+			if (properties != null)
+			{
+				if (properties["configType"] != null)
+					configType = properties["configType"].ToUpperInvariant();
+
+				if (properties["configFile"] != null)
+				{
+					configFile = properties["configFile"];
+					if (configFile.StartsWith("~/") || configFile.StartsWith("~\\"))
+						configFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory.TrimEnd('/', '\\') + "/", configFile[2..]);
+				}
+
+				if (configType == "FILE")
+				{
+					if (string.IsNullOrWhiteSpace(configFile))
+						throw new ConfigurationException("Configuration property 'configFile' must be set for NLog configuration of type 'FILE'.");
+
+					if (!File.Exists(configFile))
+						throw new ConfigurationException($"NLog configuration file '{configFile}' does not exist.");
+				}
+			}
+
+			switch (configType)
+			{
+				case "INLINE":
+					break;
+				case "FILE":
+					NLog.LogManager.Configuration = new NLog.Config.XmlLoggingConfiguration(configFile);
+					break;
+				default:
+					break;
+			}
+		}
+
+		protected override ILog CreateLogger(string name) =>
+			new NLogLogger(NLog.LogManager.GetLogger(name));
+	}
+}

--- a/Common.Logging.NLog53/NLogLogicalThreadVariablesContext.cs
+++ b/Common.Logging.NLog53/NLogLogicalThreadVariablesContext.cs
@@ -1,0 +1,98 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using System.Collections.Immutable;
+
+using NLog;
+
+namespace Common.Logging.NLog53
+{
+	public sealed class NLogLogicalThreadVariablesContext : IVariablesContext
+	{
+		private static readonly AsyncLocal<ImmutableDictionary<string, ImmutableStack<PropertyScopeEntry>>> _store = new();
+
+		private static ImmutableDictionary<string, ImmutableStack<PropertyScopeEntry>> State
+		{
+			get => _store.Value ?? ImmutableDictionary<string, ImmutableStack<PropertyScopeEntry>>.Empty;
+			set => _store.Value = value;
+		}
+
+		public void Set(string key, object value)
+		{
+			ArgumentNullException.ThrowIfNull(key);
+
+			var state = State;
+			state.TryGetValue(key, out var stack);
+			stack ??= [];
+
+			var handle = ScopeContext.PushProperty(key, value);
+			State = state.SetItem(key, stack.Push(new PropertyScopeEntry(value, handle)));
+		}
+
+		public object Get(string key)
+		{
+			if (key == null)
+				return null;
+
+			var state = State;
+			if (state.TryGetValue(key, out var stack) && !stack.IsEmpty)
+				return stack.Peek().Value;
+
+			return null;
+		}
+
+		public bool Contains(string key)
+		{
+			var state = State;
+			return key != null && state.TryGetValue(key, out var stack) && !stack.IsEmpty;
+		}
+
+		public void Remove(string key)
+		{
+			var state = State;
+			if (key == null || !state.TryGetValue(key, out var stack) || stack.IsEmpty)
+				return;
+
+			var entry = stack.Peek();
+			entry.Scope.Dispose();
+			stack = stack.Pop();
+
+			State = stack.IsEmpty
+				? state.Remove(key)
+				: state.SetItem(key, stack);
+		}
+
+		public void Clear()
+		{
+			var state = State;
+			foreach (var stack in state.Values)
+			{
+				foreach (var entry in stack)
+					entry.Scope.Dispose();
+			}
+
+			State = ImmutableDictionary<string, ImmutableStack<PropertyScopeEntry>>.Empty;
+		}
+
+		private readonly record struct PropertyScopeEntry(object Value, IDisposable Scope);
+	}
+}

--- a/Common.Logging.NLog53/NLogNestedLogicalThreadVariablesContext.cs
+++ b/Common.Logging.NLog53/NLogNestedLogicalThreadVariablesContext.cs
@@ -1,0 +1,112 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using System.Collections.Immutable;
+
+using NLog;
+
+namespace Common.Logging.NLog53
+{
+	public sealed class NLogNestedLogicalThreadVariablesContext : INestedVariablesContext
+	{
+		private static readonly AsyncLocal<ImmutableStack<NestedScopeEntry>> _stack = new();
+
+		private static ImmutableStack<NestedScopeEntry> State
+		{
+			get => _stack.Value ?? [];
+			set => _stack.Value = value;
+		}
+
+		public IDisposable Push(string text)
+		{
+			var scope = ScopeContext.PushNestedState(text);
+			var entry = new NestedScopeEntry(text, scope);
+			State = State.Push(entry);
+
+			return new PopHandle(() => Remove(entry.Scope));
+		}
+
+		public string Pop()
+		{
+			var state = State;
+			if (state.IsEmpty)
+				return null;
+
+			var entry = state.Peek();
+			entry.Scope.Dispose();
+			State = state.Pop();
+			return entry.Value;
+		}
+
+		public void Clear()
+		{
+			foreach (var entry in State)
+				entry.Scope.Dispose();
+
+			State = [];
+		}
+
+		public bool HasItems => !State.IsEmpty;
+
+		private static void Remove(IDisposable scope)
+		{
+			var state = State;
+			if (state.IsEmpty)
+				return;
+
+			NestedScopeEntry? removed = null;
+			var remaining = state.Where(x => !ReferenceEquals(x.Scope, scope)).ToArray();
+			if (remaining.Length == state.Count())
+				return;
+
+			foreach (var current in state)
+			{
+				if (ReferenceEquals(current.Scope, scope))
+				{
+					removed = current;
+					break;
+				}
+			}
+
+			if (removed.HasValue)
+				removed.Value.Scope.Dispose();
+
+			var rebuilt = ImmutableStack<NestedScopeEntry>.Empty;
+			for (var i = remaining.Length - 1; i >= 0; i--)
+				rebuilt = rebuilt.Push(remaining[i]);
+
+			State = rebuilt;
+		}
+
+		private readonly record struct NestedScopeEntry(string Value, IDisposable Scope);
+
+		private sealed class PopHandle(Action popAction) : IDisposable
+		{
+			private Action _popAction = popAction;
+
+			public void Dispose()
+			{
+				Interlocked.Exchange(ref _popAction, null)?.Invoke();
+			}
+		}
+	}
+}

--- a/Common.Logging.NLog53/NLogNestedThreadVariablesContext.cs
+++ b/Common.Logging.NLog53/NLogNestedThreadVariablesContext.cs
@@ -1,0 +1,105 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using NLog;
+
+namespace Common.Logging.NLog53
+{
+	public sealed class NLogNestedThreadVariablesContext : INestedVariablesContext
+	{
+		[ThreadStatic]
+		private static Stack<NestedScopeEntry> _stack;
+
+		public IDisposable Push(string text)
+		{
+			var scope = ScopeContext.PushNestedState(text);
+			_stack ??= new Stack<NestedScopeEntry>();
+			var entry = new NestedScopeEntry(text, scope);
+			_stack.Push(entry);
+
+			return new PopHandle(() => Remove(entry));
+		}
+
+		public string Pop()
+		{
+			if (_stack == null || _stack.Count == 0)
+				return null;
+
+			var entry = _stack.Pop();
+			entry.Scope.Dispose();
+			return entry.Value;
+		}
+
+		public void Clear()
+		{
+			if (_stack == null)
+				return;
+
+			while (_stack.Count > 0)
+				_stack.Pop().Scope.Dispose();
+		}
+
+		public bool HasItems => _stack != null && _stack.Count > 0;
+
+		private static void Remove(NestedScopeEntry entry)
+		{
+			if (_stack == null || _stack.Count == 0)
+				return;
+
+			if (ReferenceEquals(_stack.Peek().Scope, entry.Scope))
+			{
+				_stack.Pop().Scope.Dispose();
+				return;
+			}
+
+			var temp = new Stack<NestedScopeEntry>();
+			var removed = false;
+
+			while (_stack.Count > 0)
+			{
+				var current = _stack.Pop();
+				if (!removed && ReferenceEquals(current.Scope, entry.Scope))
+				{
+					current.Scope.Dispose();
+					removed = true;
+					break;
+				}
+				temp.Push(current);
+			}
+
+			while (temp.Count > 0)
+				_stack.Push(temp.Pop());
+		}
+
+		private readonly record struct NestedScopeEntry(string Value, IDisposable Scope);
+
+		private sealed class PopHandle(Action popAction) : IDisposable
+		{
+			private Action _popAction = popAction;
+
+			public void Dispose()
+			{
+				Interlocked.Exchange(ref _popAction, null)?.Invoke();
+			}
+		}
+	}
+}

--- a/Common.Logging.NLog53/NLogThreadVariablesContext.cs
+++ b/Common.Logging.NLog53/NLogThreadVariablesContext.cs
@@ -1,0 +1,100 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+// Originally taken from: https://github.com/net-commons/common-logging/pull/176
+
+using NLog;
+
+namespace Common.Logging.NLog53
+{
+	public sealed class NLogThreadVariablesContext : IVariablesContext
+	{
+		[ThreadStatic]
+		private static Dictionary<string, Stack<PropertyScopeEntry>> _store;
+
+		public void Set(string key, object value)
+		{
+			ArgumentNullException.ThrowIfNull(key);
+
+			var stack = GetOrCreate(key);
+			var handle = ScopeContext.PushProperty(key, value);
+			stack.Push(new PropertyScopeEntry(value, handle));
+		}
+
+		public object Get(string key)
+		{
+			if (key == null)
+				return null;
+
+			if (_store != null && _store.TryGetValue(key, out var stack) && stack.Count > 0)
+				return stack.Peek().Value;
+
+			return null;
+		}
+
+		public bool Contains(string key) =>
+			key != null
+			&& _store != null
+			&& _store.TryGetValue(key, out var stack)
+			&& stack.Count > 0;
+
+		public void Remove(string key)
+		{
+			if (!Contains(key))
+				return;
+
+			var stack = _store[key];
+			var entry = stack.Pop();
+			entry.Scope.Dispose();
+
+			if (stack.Count == 0)
+				_store.Remove(key);
+		}
+
+		public void Clear()
+		{
+			if (_store == null)
+				return;
+
+			foreach (var stack in _store.Values)
+			{
+				while (stack.Count > 0)
+					stack.Pop().Scope.Dispose();
+			}
+
+			_store.Clear();
+		}
+
+		private static Stack<PropertyScopeEntry> GetOrCreate(string key)
+		{
+			_store ??= new Dictionary<string, Stack<PropertyScopeEntry>>(StringComparer.Ordinal);
+
+			if (!_store.TryGetValue(key, out var stack))
+			{
+				stack = new Stack<PropertyScopeEntry>();
+				_store[key] = stack;
+			}
+
+			return stack;
+		}
+
+		private readonly record struct PropertyScopeEntry(object Value, IDisposable Scope);
+	}
+}

--- a/Common.Logging.Nlog53.Tests/Common.Logging.Nlog53.Tests.csproj
+++ b/Common.Logging.Nlog53.Tests/Common.Logging.Nlog53.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Company>Uanataca S.A.U.</Company>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<AssemblyVersion>0.0.0.0</AssemblyVersion>
+		<FileVersion>0.0.0.0</FileVersion>
+		<Version>0.0.0.0</Version>
+		<Authors>Evicertia</Authors>
+		<Copyright>Copyright Uanataca S.A.U. 2026</Copyright>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/evicertia/Common.Logging.Extras</PackageProjectUrl>
+		<PackageId>Common.Logging.NLog53.Tests</PackageId>
+		<RootNamespace>Common.Logging.NLog53.Tests</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Common.Logging.NLog53\Common.Logging.NLog53.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Common.Logging.Nlog53.Tests/GlobalUsings.cs
+++ b/Common.Logging.Nlog53.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using NUnit.Framework;
+global using System.Collections.Concurrent;

--- a/Common.Logging.Nlog53.Tests/LoggerTests.cs
+++ b/Common.Logging.Nlog53.Tests/LoggerTests.cs
@@ -1,0 +1,53 @@
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+
+namespace Common.Logging.NLog53.Tests
+{
+	[TestFixture]
+	[NonParallelizable]
+	public class LoggerTests
+	{
+		private MemoryTarget _target;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_target = new MemoryTarget("memory")
+			{
+				Layout = "${message}"
+			};
+
+			var config = new LoggingConfiguration();
+			config.AddRuleForAllLevels(_target);
+			NLog.LogManager.Configuration = config;
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			ScopeContext.Clear();
+			NLog.LogManager.Configuration = null;
+			_target?.Dispose();
+		}
+
+		[Test]
+		public void InfoFormat_With_Named_Placeholder_Does_Not_Throw()
+		{
+			var sut = new NLogLogger(NLog.LogManager.GetLogger("nlog53-test"));
+
+			Assert.That(() => sut.InfoFormat("Unsuccessful authentication by user {user.email}", "user@test"), Throws.Nothing);
+		}
+
+		[Test]
+		public void InfoFormat_With_Named_Placeholder_Writes_Message_With_Value()
+		{
+			var sut = new NLogLogger(NLog.LogManager.GetLogger("nlog53-test"));
+
+			sut.InfoFormat("Unsuccessful authentication by user {user.email}", "user@test");
+
+			Assert.That(_target.Logs.Count, Is.EqualTo(1));
+			Assert.That(_target.Logs[0], Does.Contain("user@test"));
+		}
+	}
+}

--- a/Common.Logging.Nlog53.Tests/NLogLoggerFactoryAdapterTests.cs
+++ b/Common.Logging.Nlog53.Tests/NLogLoggerFactoryAdapterTests.cs
@@ -1,0 +1,96 @@
+using Common.Logging.Configuration;
+using NLog.Config;
+using NLog.Targets;
+
+namespace Common.Logging.NLog53.Tests
+{
+	[TestFixture]
+	[NonParallelizable]
+	public class NLogLoggerFactoryAdapterTests
+	{
+		[TearDown]
+		public void TearDown()
+		{
+			NLog.LogManager.Configuration = null;
+		}
+
+		[Test]
+		public void Factory_Adapter_Default_Creates_Logger_Without_Throwing()
+		{
+			var config = new LoggingConfiguration();
+			config.AddRuleForAllLevels(new MemoryTarget("memory") { Layout = "${message}" });
+			NLog.LogManager.Configuration = config;
+
+			var sut = new NLogLoggerFactoryAdapter();
+
+			Assert.That(() => sut.GetLogger("factory-test"), Throws.Nothing);
+		}
+
+		[Test]
+		public void Factory_Adapter_File_Mode_Without_Path_Throws_Configuration_Exception()
+		{
+			var properties = new NameValueCollection()
+			{
+				["configType"] = "FILE"
+			};
+
+			Assert.That(() => new NLogLoggerFactoryAdapter(properties), Throws.TypeOf<ConfigurationException>());
+		}
+
+		[Test]
+		public void Factory_Adapter_File_Mode_With_Missing_File_Throws_Configuration_Exception()
+		{
+			var properties = new NameValueCollection()
+			{
+				["configType"] = "FILE",
+				["configFile"] = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.config")
+			};
+
+			Assert.That(() => new NLogLoggerFactoryAdapter(properties), Throws.TypeOf<ConfigurationException>());
+		}
+
+		[Test]
+		public void Factory_Adapter_External_Mode_Uses_Existing_NLog_Configuration()
+		{
+			var target = new MemoryTarget("existing") { Layout = "${message}" };
+			var config = new LoggingConfiguration();
+			config.AddRuleForAllLevels(target);
+			NLog.LogManager.Configuration = config;
+
+			var properties = new NameValueCollection()
+			{
+				["configType"] = "EXTERNAL"
+			};
+
+			var sut = new NLogLoggerFactoryAdapter(properties);
+			var logger = sut.GetLogger("external-mode");
+
+			logger.Info("hello");
+
+			Assert.That(target.Logs, Has.Count.EqualTo(1));
+			Assert.That(target.Logs[0], Is.EqualTo("hello"));
+		}
+
+		[Test]
+		public void Factory_Adapter_Inline_Mode_Uses_Existing_NLog_Configuration()
+		{
+			var target = new MemoryTarget("existing-inline") { Layout = "${message}" };
+			var config = new LoggingConfiguration();
+			config.AddRuleForAllLevels(target);
+			NLog.LogManager.Configuration = config;
+
+			var properties = new NameValueCollection()
+			{
+				["configType"] = "INLINE"
+			};
+
+			var sut = new NLogLoggerFactoryAdapter(properties);
+			var logger = sut.GetLogger("inline-mode");
+
+			logger.Info("hello-inline");
+
+			Assert.That(target.Logs, Has.Count.EqualTo(1));
+			Assert.That(target.Logs[0], Is.EqualTo("hello-inline"));
+		}
+	}
+}

--- a/Common.Logging.Nlog53.Tests/NLogVariablesContextTests.cs
+++ b/Common.Logging.Nlog53.Tests/NLogVariablesContextTests.cs
@@ -1,0 +1,155 @@
+namespace Common.Logging.NLog53.Tests
+{
+	[TestFixture]
+	[NonParallelizable]
+	public class NLogVariablesContextTests
+	{
+		[TearDown]
+		public void TearDown()
+		{
+			new NLogThreadVariablesContext().Clear();
+			new NLogLogicalThreadVariablesContext().Clear();
+			new NLogGlobalVariablesContext().Clear();
+		}
+
+		[Test]
+		public void Thread_Context_Set_Then_Get_Returns_Value()
+		{
+			var sut = new NLogThreadVariablesContext();
+
+			sut.Set("k", "v1");
+
+			Assert.That(sut.Contains("k"), Is.True);
+			Assert.That(sut.Get("k"), Is.EqualTo("v1"));
+		}
+
+		[Test]
+		public void Thread_Context_Set_Twice_Then_Remove_Restores_Previous_Value()
+		{
+			var sut = new NLogThreadVariablesContext();
+
+			sut.Set("k", "v1");
+			sut.Set("k", "v2");
+			sut.Remove("k");
+
+			Assert.That(sut.Contains("k"), Is.True);
+			Assert.That(sut.Get("k"), Is.EqualTo("v1"));
+
+			sut.Remove("k");
+
+			Assert.That(sut.Contains("k"), Is.False);
+			Assert.That(sut.Get("k"), Is.Null);
+		}
+
+		[Test]
+		public async Task Logical_Context_Set_Then_Await_Preserves_Value()
+		{
+			var sut = new NLogLogicalThreadVariablesContext();
+
+			sut.Set("k", "v1");
+			await Task.Yield();
+
+			Assert.That(sut.Contains("k"), Is.True);
+			Assert.That(sut.Get("k"), Is.EqualTo("v1"));
+		}
+
+		[Test]
+		public async Task Logical_Context_Set_Twice_Across_Await_Then_Remove_Restores_Previous_Value()
+		{
+			var sut = new NLogLogicalThreadVariablesContext();
+
+			sut.Set("k", "v1");
+			await Task.Yield();
+			sut.Set("k", "v2");
+			await Task.Yield();
+
+			Assert.That(sut.Get("k"), Is.EqualTo("v2"));
+
+			sut.Remove("k");
+			await Task.Yield();
+
+			Assert.That(sut.Get("k"), Is.EqualTo("v1"));
+			Assert.That(sut.Contains("k"), Is.True);
+
+			sut.Remove("k");
+			Assert.That(sut.Contains("k"), Is.False);
+		}
+
+		[Test]
+		public async Task Logical_Context_Clear_Across_Await_Removes_All_Values()
+		{
+			var sut = new NLogLogicalThreadVariablesContext();
+
+			sut.Set("k1", "v1");
+			sut.Set("k2", "v2");
+			await Task.Yield();
+
+			sut.Clear();
+			await Task.Yield();
+
+			Assert.That(sut.Contains("k1"), Is.False);
+			Assert.That(sut.Contains("k2"), Is.False);
+			Assert.That(sut.Get("k1"), Is.Null);
+			Assert.That(sut.Get("k2"), Is.Null);
+		}
+
+		[Test]
+		public async Task Logical_Context_Task_Run_Child_Override_Does_Not_Modify_Parent_State()
+		{
+			var sut = new NLogLogicalThreadVariablesContext();
+			sut.Set("k", "parent");
+
+			var childValue = await Task.Run(() => {
+				Assert.That(sut.Get("k"), Is.EqualTo("parent"));
+				sut.Set("k", "child");
+				return sut.Get("k");
+			});
+
+			Assert.That(childValue, Is.EqualTo("child"));
+			Assert.That(sut.Get("k"), Is.EqualTo("parent"));
+		}
+
+		[Test]
+		public async Task Logical_Context_Parallel_For_Does_Not_Leak_Child_Value_To_Parent()
+		{
+			var sut = new NLogLogicalThreadVariablesContext();
+			sut.Set("k", "parent");
+
+			var errors = new ConcurrentQueue<Exception>();
+
+			Parallel.For(0, 32, i => {
+				try
+				{
+					Assert.That(sut.Get("k"), Is.EqualTo("parent"));
+					sut.Set("k", $"child-{i}");
+					Assert.That(sut.Get("k"), Is.EqualTo($"child-{i}"));
+					sut.Remove("k");
+					Assert.That(sut.Get("k"), Is.EqualTo("parent"));
+				}
+				catch (Exception ex)
+				{
+					errors.Enqueue(ex);
+				}
+			});
+
+			await Task.Yield();
+
+			Assert.That(errors, Is.Empty);
+			Assert.That(sut.Get("k"), Is.EqualTo("parent"));
+		}
+
+		[Test]
+		public void Global_Context_Set_Then_Clear_Removes_Value()
+		{
+			var sut = new NLogGlobalVariablesContext();
+
+			sut.Set("k", "v1");
+			Assert.That(sut.Contains("k"), Is.True);
+
+			sut.Clear();
+
+			Assert.That(sut.Contains("k"), Is.False);
+			Assert.That(sut.Get("k"), Is.Null);
+		}
+	}
+}

--- a/Common.Logging.Nlog53.Tests/NestedVariablesContextTests.cs
+++ b/Common.Logging.Nlog53.Tests/NestedVariablesContextTests.cs
@@ -1,0 +1,151 @@
+namespace Common.Logging.NLog53.Tests
+{
+	[TestFixture]
+	[NonParallelizable]
+	public class NestedVariablesContextTests
+	{
+		[TearDown]
+		public void TearDown()
+		{
+			new NLogNestedThreadVariablesContext().Clear();
+			new NLogNestedLogicalThreadVariablesContext().Clear();
+		}
+
+		[Test]
+		public void Nested_Thread_Context_Push_Then_Pop_Returns_Last_Value()
+		{
+			var sut = new NLogNestedThreadVariablesContext();
+
+			sut.Push("a");
+			sut.Push("b");
+
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("b"));
+			Assert.That(sut.Pop(), Is.EqualTo("a"));
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public void Nested_Thread_Context_Dispose_Outer_Before_Inner_Keeps_Stack_Consistent()
+		{
+			var sut = new NLogNestedThreadVariablesContext();
+
+			using var outer = sut.Push("outer");
+			using var inner = sut.Push("inner");
+
+			outer.Dispose();
+
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("inner"));
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public void Nested_Logical_Context_Push_Then_Pop_Returns_Last_Value()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+
+			sut.Push("a");
+			sut.Push("b");
+
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("b"));
+			Assert.That(sut.Pop(), Is.EqualTo("a"));
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public void Nested_Logical_Context_Dispose_Outer_Before_Inner_Keeps_Stack_Consistent()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+
+			using var outer = sut.Push("outer");
+			using var inner = sut.Push("inner");
+
+			outer.Dispose();
+
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("inner"));
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public async Task Nested_Logical_Context_Push_Across_Await_Then_Pop_Preserves_Order()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+
+			sut.Push("a");
+			await Task.Yield();
+			sut.Push("b");
+			await Task.Yield();
+
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("b"));
+			Assert.That(sut.Pop(), Is.EqualTo("a"));
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public async Task Nested_Logical_Context_Dispose_Pushed_Scope_Across_Await_Removes_Item()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+
+			using var scope = sut.Push("a");
+			await Task.Yield();
+
+			Assert.That(sut.HasItems, Is.True);
+
+			scope.Dispose();
+			await Task.Yield();
+
+			Assert.That(sut.HasItems, Is.False);
+		}
+
+		[Test]
+		public async Task Nested_Logical_Context_Task_Run_Child_Push_Does_Not_Modify_Parent_Stack()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+			using var parent = sut.Push("parent");
+
+			var childTop = await Task.Run(() =>
+			{
+				Assert.That(sut.HasItems, Is.True);
+				using var child = sut.Push("child");
+				return sut.Pop();
+			});
+
+			Assert.That(childTop, Is.EqualTo("child"));
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("parent"));
+		}
+
+		[Test]
+		public async Task Nested_Logical_Context_Parallel_For_Does_Not_Leak_Child_Stack_To_Parent()
+		{
+			var sut = new NLogNestedLogicalThreadVariablesContext();
+			using var parent = sut.Push("parent");
+
+			var errors = new ConcurrentQueue<Exception>();
+
+			Parallel.For(0, 24, i =>
+			{
+				try
+				{
+					using var child = sut.Push($"child-{i}");
+					Assert.That(sut.Pop(), Is.EqualTo($"child-{i}"));
+					Assert.That(sut.HasItems, Is.True);
+				}
+				catch (Exception ex)
+				{
+					errors.Enqueue(ex);
+				}
+			});
+
+			await Task.Yield();
+
+			Assert.That(errors, Is.Empty);
+			Assert.That(sut.HasItems, Is.True);
+			Assert.That(sut.Pop(), Is.EqualTo("parent"));
+		}
+	}
+}


### PR DESCRIPTION
Introduce a new Common.Logging.NLog53 package compatible with NLog 5.3.4, including full logger/factory/context implementations and license attribution. Add comprehensive NUnit tests (async, parallel, EXTERNAL/INLINE config), normalize NLog53 naming/casing across solution and AppVeyor, and run both Scopes and NLog53 test suites in CI.

Regards, Juanje